### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
 
 # Use Sass to process CSS
-# gem "sassc-rails"
+gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,6 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'payjp'
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,14 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -282,6 +290,7 @@ GEM
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.2)
+    tilt (2.2.0)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -337,6 +346,7 @@ DEPENDENCIES
   rails (~> 7.0.0)
   rspec-rails (~> 4.0.0)
   rubocop
+  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -111,6 +113,14 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -138,10 +148,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.6)
       date
@@ -152,6 +166,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
@@ -160,6 +175,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.5.3)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -206,9 +223,16 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.6)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -265,6 +289,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -297,11 +324,13 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faker-japanese
+  gon
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  payjp
   pg
   pry-rails
   puma (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Things you may want to cover:
 
 | Column        | Type       | Options                        |
 | ------------- | ---------- | ------------------------------ |
-| postal_code   | integer    | null: false                    |
+| postal_code   | string     | null: false                    |
 | prefecture_id | integer    | null: false                    |
 | city          | string     | null: false                    |
 | street_num    | string     | null: false                    |

--- a/app/assets/stylesheets/items/index.css
+++ b/app/assets/stylesheets/items/index.css
@@ -9,7 +9,7 @@ a {
 /* 画面上部の「人生を変えるフリマアプリ」帯部分 */
 .title-contents {
   width: 100vw;
-  background-image: image-url('furima-header01.png');
+  background-image: url('furima-header01.png');
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top center;
@@ -124,7 +124,7 @@ a {
 /* 画面中央の「会員数日本一位」帯部分*/
 .ad-contents {
   width: 100vw;
-  background-image: image-url('furima-header02.png');
+  background-image: url('furima-header02.png');
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,9 @@ class ItemsController < ApplicationController
     unless current_user.id == @item.user_id 
       redirect_to root_path
     end  
+    if @item.order.present?
+      redirect_to root_path
+    end
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update ]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order("created_at DESC")
@@ -58,6 +58,10 @@ class ItemsController < ApplicationController
           .merge(user_id: current_user.id)
   end
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def move_to_index
     unless user_signed_in?
       redirect_to new_user_session_path
@@ -65,10 +69,6 @@ class ItemsController < ApplicationController
     if @item.order.present?
       redirect_to root_path
     end
-  end
-
-  def set_item
-    @item = Item.find(params[:id])
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -59,6 +59,9 @@ class ItemsController < ApplicationController
     unless user_signed_in?
       redirect_to new_user_session_path
     end
+    if @item.order.present?
+      redirect_to root_path
+    end
   end
 
   def set_item

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,20 +1,19 @@
 class OrdersController < ApplicationController
   before_action :authenticate_user!, except: :index
+  before_action :set_order, only: [:index, :create]
 
   def index
-  end
-  
-  def new
     @order_address = OrderAddress.new
   end
-
+  
   def create
+    @user = current_user
     @order_address = OrderAddress.new(order_params)
     if @order_address.valid?
-      @order_address.save
+      @order_address.save(@user.id, @item.id)
       redirect_to root_path
     else 
-      render :new, status: :unprocessable_entity
+      render :index, status: :unprocessable_entity
     end
   end
 
@@ -23,6 +22,10 @@ class OrdersController < ApplicationController
   def order_params
     params.require(:order_address)
           .permit(:postal_code, :prefecture_id, :city, :street_num, :building_num, :phone_num)
-          .merge(user_id: current_user_id)
+          .merge(user_id: current_user.id, item_id: params[:item_id])
   end
+
+  def set_order
+    @item = Item.find(params[:item_id])
+  end 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,6 +3,7 @@ class OrdersController < ApplicationController
   before_action :set_order, only: [:index, :create]
 
   def index
+    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
     @order_address = OrderAddress.new
   end
   
@@ -10,6 +11,12 @@ class OrdersController < ApplicationController
     @user = current_user
     @order_address = OrderAddress.new(order_params)
     if @order_address.valid?
+      Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+      Payjp::Charge.create(
+        amount: @item[:price],
+        card: order_params[:token],
+        currency: 'jpy'
+      )
       @order_address.save(@user.id, @item.id)
       redirect_to root_path
     else 
@@ -22,7 +29,7 @@ class OrdersController < ApplicationController
   def order_params
     params.require(:order_address)
           .permit(:postal_code, :prefecture_id, :city, :street_num, :building_num, :phone_num)
-          .merge(user_id: current_user.id, item_id: params[:item_id])
+          .merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
   end
 
   def set_order

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,28 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!, except: :index
+
+  def index
+  end
+  
+  def new
+    @order_address = OrderAddress.new
+  end
+
+  def create
+    @order_address = OrderAddress.new(order_params)
+    if @order_address.valid?
+      @order_address.save
+      redirect_to root_path
+    else 
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def order_params
+    params.require(:order_address)
+          .permit(:postal_code, :prefecture_id, :city, :street_num, :building_num, :phone_num)
+          .merge(user_id: current_user_id)
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,5 @@
 class OrdersController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!
   before_action :set_order, only: [:index, :create]
 
   def index
@@ -34,5 +34,8 @@ class OrdersController < ApplicationController
 
   def set_order
     @item = Item.find(params[:item_id])
+    if (current_user.id == @item.user_id ) || @item.order.present?
+      redirect_to root_path
+    end
   end 
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  const publicKey = gon.public_key
+  const payjp = Payjp(publicKey)
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });   
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("turbo:load", pay);

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,5 +19,5 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
-
+  has_one :order
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :address
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,21 +1,23 @@
 class OrderAddress
   include ActiveModel::Model
   attr_accessor :postal_code, :prefecture_id, :city, :street_num, :building_num, :phone_num,
-                :order_id, :user_id, :item_id
+                :user_id, :item_id
 
   with_options presence: true do
-    validates :postal_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
-    validates :city,            format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "は（全角）で入力する必要があります"	}  
-    validates :street_num,      format: { with: /\A[ぁ-んァ-ヶ一-龥々ー0-9a-zA-Z^\-]+\z/, message: "は ハイフン（-）以外の記号は使用できません" }
-    validates :phone_num,       format: { with: /\A\d{1,11}\z/, message: "は（半角数字）最大11文字で入力する必要があります" }
-    validates :order_id
+    validates :postal_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)", allow_blank: true}
+    validates :city,            format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "は（全角）で入力する必要があります", allow_blank: true	}  
+    validates :street_num,      format: { with: /\A[ぁ-んァ-ヶ一-龥々ー0-9a-zA-Z^\-]+\z/, message: "は ハイフン（-）以外の記号は使用できません", allow_blank: true }
+    validates :phone_num,       format: { with: /\A\d{1,11}\z/, message: "は（半角数字）最大11文字で入力する必要があります", allow_blank: true }
     validates :user_id
     validates :item_id
+   
   end 
   validates :prefecture_id,   numericality: { other_than: 1, message: "can't be blank" }
 
-  def save
+  def save(user_id, item_id)
     order = Order.create(user_id: user_id, item_id: item_id)
-    Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, street_num: street_num, phone_num: phone_num, order_id: order.id)
+    Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, street_num: street_num, building_num: building_num, phone_num: phone_num, order_id: order.id)
   end
 end
+
+ 

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -10,6 +10,7 @@ class OrderAddress
     validates :phone_num,       format: { with: /\A\d{10,11}\z/, message: "は（半角数字）10~11文字で入力する必要があります", allow_blank: true}
     validates :user_id
     validates :item_id
+    validates :token
    
   end 
   validates :prefecture_id,   numericality: { other_than: 1, message: "can't be blank" }

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -20,14 +20,6 @@ class OrderAddress
     Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, street_num: street_num, building_num: building_num, phone_num: phone_num, order_id: order.id)
   end
 
-  def user=(user)
-    self.user_id = user
-  end
-
-  def item=(item)
-    self.item_id = item
-  end
-
 end
 
  

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,21 @@
+class OrderAddress
+  include ActiveModel::Model
+  attr_accessor :postal_code, :prefecture_id, :city, :street_num, :building_num, :phone_num,
+                :order_id, :user_id, :item_id
+
+  with_options presence: true do
+    validates :postal_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
+    validates :city,            format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "は（全角）で入力する必要があります"	}  
+    validates :street_num,      format: { with: /\A[ぁ-んァ-ヶ一-龥々ー0-9a-zA-Z^\-]+\z/, message: "は ハイフン（-）以外の記号は使用できません" }
+    validates :phone_num,       format: { with: /\A\d{1,11}\z/, message: "は（半角数字）最大11文字で入力する必要があります" }
+    validates :order_id
+    validates :user_id
+    validates :item_id
+  end 
+  validates :prefecture_id,   numericality: { other_than: 1, message: "can't be blank" }
+
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, street_num: street_num, phone_num: phone_num, order_id: order.id)
+  end
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -15,7 +15,7 @@ class OrderAddress
   end 
   validates :prefecture_id,   numericality: { other_than: 1, message: "can't be blank" }
 
-  def save(user_id, item_id)
+  def save
     order = Order.create(user_id: user_id, item_id: item_id)
     Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, street_num: street_num, building_num: building_num, phone_num: phone_num, order_id: order.id)
   end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -5,9 +5,9 @@ class OrderAddress
 
   with_options presence: true do
     validates :postal_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)", allow_blank: true}
-    validates :city,            format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "は（全角）で入力する必要があります", allow_blank: true	}  
-    validates :street_num,      format: { with: /\A[ぁ-んァ-ヶ一-龥々ー0-9a-zA-Z^\-]+\z/, message: "は ハイフン（-）以外の記号は使用できません", allow_blank: true }
-    validates :phone_num,       format: { with: /\A\d{1,11}\z/, message: "は（半角数字）最大11文字で入力する必要があります", allow_blank: true }
+    validates :city  
+    validates :street_num
+    validates :phone_num,       format: { with: /\A\d{10,11}\z/, message: "は（半角数字）10~11文字で入力する必要があります", allow_blank: true}
     validates :user_id
     validates :item_id
    
@@ -18,6 +18,15 @@ class OrderAddress
     order = Order.create(user_id: user_id, item_id: item_id)
     Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, street_num: street_num, building_num: building_num, phone_num: phone_num, order_id: order.id)
   end
+
+  def user=(user)
+    self.user_id = user
+  end
+
+  def item=(item)
+    self.item_id = item
+  end
+
 end
 
  

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,7 +1,7 @@
 class OrderAddress
   include ActiveModel::Model
   attr_accessor :postal_code, :prefecture_id, :city, :street_num, :building_num, :phone_num,
-                :user_id, :item_id
+                :user_id, :item_id, :token
 
   with_options presence: true do
     validates :postal_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)", allow_blank: true}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,5 +17,5 @@ class User < ApplicationRecord
   validates :birth_day,        presence: true
 
   has_many :items
-
+  has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,11 @@
         <div class='item-img-content'>
           <%= image_tag(item.image, class: "item-img") %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <% if item.order.present? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <% end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
         <p class="or-text">or</p>
         <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
-        <%= link_to "購入画面に進む", "#", class:"item-red-btn"%>
+        <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,12 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag(@item.image ,class:"item-box-img") %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+
+        <% if @item.order.present? %>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+        <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -24,12 +25,14 @@
     </div>
 
     <% if user_signed_in? %>
-      <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
-      <% else %>
-        <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
+      <% unless @item.order.present?%>
+        <% if current_user.id == @item.user_id %>
+          <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
+        <% else %>
+          <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,15 +24,13 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
-      <% unless @item.order.present?%>
-        <% if current_user.id == @item.user_id %>
-          <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-          <p class="or-text">or</p>
-          <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
-        <% else %>
-          <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
-        <% end %>
+    <% if user_signed_in? && !@item.order.present?%> 
+      <% if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,3 +1,5 @@
+<%= include_gon %>
+
 <%= render "shared/second-header"%>
 
 <div class='transaction-contents'>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag(@item.image, class: 'buy-item-img') %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.title %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= FeesBurden.find(@item.fees_burden_id).name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,14 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_address, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+
+    <%= render 'shared/error_messages', model: f.object %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -79,42 +81,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :street_num, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building_num, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_num, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
-
+  config.active_job.queue_adapter = :inline
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "price", to: "price.js"
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
  root to: 'items#index'
- resources :items
- resources :orders, only: [:index, :new, :create]
+ resources :items do
+   resources :orders, only: [:index, :create]
+ end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
  root to: 'items#index'
  resources :items
+ resources :orders, only: [:index, :new, :create]
 end

--- a/db/migrate/20230801020609_create_orders.rb
+++ b/db/migrate/20230801020609_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references  :user,    null: false,  foreign_key: true
+      t.references  :item,    null: false,  foreign_key: true
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230801020624_create_addresses.rb
+++ b/db/migrate/20230801020624_create_addresses.rb
@@ -1,0 +1,15 @@
+class CreateAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :addresses do |t|
+      t.string      :postal_code,       null: false
+      t.integer     :prefecture_id,     null: false
+      t.string      :city,              null: false
+      t.string      :street_num,        null: false
+      t.string      :building_num
+      t.string      :phone_num,         null: false
+      t.references  :order,             null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_222904) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_01_020624) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_222904) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "addresses", charset: "utf8mb4", force: :cascade do |t|
+    t.string "postal_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "street_num", null: false
+    t.string "building_num"
+    t.string "phone_num", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
   create_table "items", charset: "utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
@@ -52,6 +65,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_222904) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", charset: "utf8mb4", force: :cascade do |t|
@@ -74,5 +96,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_222904) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/furima.dio
+++ b/furima.dio
@@ -1,58 +1,52 @@
 <mxfile host="65bd71144e">
     <diagram id="FL00jLi_GdnBjen2LCC1" name="ページ1">
-        <mxGraphModel dx="542" dy="825" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="393" dy="907" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
-                <mxCell id="57" value="users" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
+                <mxCell id="57" value="users" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
                     <mxGeometry x="40" y="40" width="160" height="200" as="geometry"/>
                 </mxCell>
-                <mxCell id="58" value="nickname&#10;email&#10;encrypted_password&#10;last_name_em&#10;first_name_em&#10;last_name_kana&#10;first_name_kana&#10;birth_day" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="57">
+                <mxCell id="58" value="nickname&#10;email&#10;encrypted_password&#10;last_name_em&#10;first_name_em&#10;last_name_kana&#10;first_name_kana&#10;birth_day" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="57" vertex="1">
                     <mxGeometry y="26" width="160" height="174" as="geometry"/>
                 </mxCell>
-                <mxCell id="61" value="items" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
+                <mxCell id="61" value="items" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
                     <mxGeometry x="320" y="40" width="160" height="200" as="geometry"/>
                 </mxCell>
-                <mxCell id="64" value="title&#10;description&#10;category_id&#10;condition_id&#10;fees_burden_id&#10;prefecture_id&#10;days_to_ship_id&#10;price&#10;user" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="61">
+                <mxCell id="64" value="title&#10;description&#10;category_id&#10;condition_id&#10;fees_burden_id&#10;prefecture_id&#10;days_to_ship_id&#10;price&#10;user" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="61" vertex="1">
                     <mxGeometry y="26" width="160" height="174" as="geometry"/>
                 </mxCell>
-                <mxCell id="65" value="addresses" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
+                <mxCell id="65" value="addresses" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
                     <mxGeometry x="40" y="320" width="160" height="200" as="geometry"/>
                 </mxCell>
-                <mxCell id="68" value="postal_code&#10;prefecture_id&#10;city&#10;street_num&#10;building_num&#10;phone_num&#10;user&#10;item" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="65">
+                <mxCell id="68" value="postal_code&#10;prefecture_id&#10;city&#10;street_num&#10;building_num&#10;phone_num&#10;user&#10;item" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="65" vertex="1">
                     <mxGeometry y="26" width="160" height="174" as="geometry"/>
                 </mxCell>
-                <mxCell id="69" value="orders" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
+                <mxCell id="69" value="orders" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
                     <mxGeometry x="320" y="320" width="160" height="200" as="geometry"/>
                 </mxCell>
-                <mxCell id="72" value="user&#10;item&#10;address" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="69">
+                <mxCell id="72" value="user&#10;item&#10;address" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="69" vertex="1">
                     <mxGeometry y="26" width="160" height="174" as="geometry"/>
                 </mxCell>
-                <mxCell id="77" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERoneToMany;entryX=-0.014;entryY=0.311;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="58" target="72">
+                <mxCell id="77" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERoneToMany;entryX=-0.014;entryY=0.311;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="58" target="72" edge="1">
                     <mxGeometry width="100" height="100" relative="1" as="geometry">
                         <mxPoint x="200" y="200" as="sourcePoint"/>
                         <mxPoint x="300" y="100" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="79" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERoneToMany;entryX=-0.014;entryY=0.314;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" target="64">
+                <mxCell id="79" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERoneToMany;entryX=-0.014;entryY=0.314;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" target="64" edge="1">
                     <mxGeometry width="100" height="100" relative="1" as="geometry">
                         <mxPoint x="200" y="120" as="sourcePoint"/>
                         <mxPoint x="300" y="20" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="80" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERoneToMany;entryX=0.996;entryY=0.311;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" target="68">
-                    <mxGeometry width="100" height="100" relative="1" as="geometry">
-                        <mxPoint x="200" y="200" as="sourcePoint"/>
-                        <mxPoint x="300" y="100" as="targetPoint"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="81" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERmandOne;startArrow=ERmandOne;entryX=0;entryY=0.77;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" target="72">
+                <mxCell id="81" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERmandOne;startArrow=ERmandOne;entryX=0;entryY=0.77;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" target="72" edge="1">
                     <mxGeometry width="100" height="100" relative="1" as="geometry">
                         <mxPoint x="200" y="480" as="sourcePoint"/>
                         <mxPoint x="300" y="380" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="82" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERmandOne;startArrow=ERmandOne;exitX=0.994;exitY=0.645;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="64" target="72">
+                <mxCell id="82" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERmandOne;startArrow=ERmandOne;exitX=0.994;exitY=0.645;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="64" target="72" edge="1">
                     <mxGeometry width="100" height="100" relative="1" as="geometry">
                         <mxPoint x="490" y="190" as="sourcePoint"/>
                         <mxPoint x="420" y="120" as="targetPoint"/>

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :order_address do
+    postal_code           {'123-4567'}
+    prefecture_id         {Faker::Number.between(from: 2, to: 48)}
+    city                  {Faker::Address.city}
+    street_num            {Faker::Address.street_address}
+    building_num          {Faker::Address.building_number}
+    phone_num             {Faker::PhoneNumber.phone_number.gsub(/\D/, '')[0..10]}
+    
+  end 
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     street_num            {Faker::Address.street_address}
     building_num          {Faker::Address.building_number}
     phone_num             {Faker::PhoneNumber.phone_number.gsub(/\D/, '')[0..10]}
+    token                 {Faker::String.random(length: 32)}
     
   end 
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe OrderAddress, type: :model do
   before do
-    @user = FactoryBot.create(:user)
-    @item = FactoryBot.create(:item)
-    @order_address = FactoryBot.build(:order_address, user: @user, item: @item)
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item)
+    @order_address = FactoryBot.build(:order_address, user_id: user.id, item_id: item.id)
   end
 
   describe '商品購入機能' do
@@ -55,13 +55,15 @@ RSpec.describe OrderAddress, type: :model do
         @order_address.valid?
         expect(@order_address.errors.full_messages).to include("Phone num can't be blank")
       end
-      it "phone_numが9文字以下/12文字以上では購入できない" do
-        phone_num = ['123456789', '123456789012']
-        phone_num.each do |phone| 
-          @order_address.phone_num = phone
-          @order_address.valid?
-          expect(@order_address.errors.full_messages).to include("Phone num は（半角数字）10~11文字で入力する必要があります")
-        end
+      it "phone_numが9文字以下では購入できない" do 
+        @order_address.phone_num = '123456789'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num は（半角数字）10~11文字で入力する必要があります")
+      end
+      it "phone_numが12文字以上では購入できない" do 
+        @order_address.phone_num = '123456789012'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num は（半角数字）10~11文字で入力する必要があります")
       end
       it "phone_numが（半角数字）以外では購入できない" do
         phone_num = ['123-456-7890', '１２３４５６７']

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  before do
+    @user = FactoryBot.create(:user)
+    @item = FactoryBot.create(:item)
+    @order_address = FactoryBot.build(:order_address, user: @user, item: @item)
+  end
+
+  describe '商品購入機能' do
+
+    context '商品購入できる場合' do
+      it 'すべての項目が正しく入力できていれば購入できる' do
+        expect(@order_address).to be_valid
+      end
+      it 'building_numは空でも購入できる' do
+        @order_address.building_num = ''
+        expect(@order_address).to be_valid
+      end
+    end
+
+    context '商品購入できない場合' do
+      it "postal_codeが空では購入できない" do
+        @order_address.postal_code = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Postal code can't be blank")
+      end
+      it "postal_codeにハイフン(―)がないと購入できない" do
+        @order_address.postal_code = '1234567'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Postal code is invalid. Include hyphen(-)")
+      end
+      it "postal_codeのハイフン(―)の位置が誤っていると購入できない" do
+        @order_address.postal_code = '1234-567'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Postal code is invalid. Include hyphen(-)")
+      end
+      it "prefecture_idが空では登録できない" do
+        @order_address.prefecture_id = 1
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it "cityが空では購入できない" do
+        @order_address.city = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("City can't be blank")
+      end
+      it "street_numが空では購入できない" do
+        @order_address.street_num = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Street num can't be blank")
+      end
+      it "phone_numが空では購入できない" do
+        @order_address.phone_num = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone num can't be blank")
+      end
+      it "phone_numが9文字以下/12文字以上では購入できない" do
+        phone_num = ['123456789', '123456789012']
+        phone_num.each do |phone| 
+          @order_address.phone_num = phone
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Phone num は（半角数字）10~11文字で入力する必要があります")
+        end
+      end
+      it "phone_numが（半角数字）以外では購入できない" do
+        phone_num = ['123-456-7890', '１２３４５６７']
+        phone_num.each do |phone|
+          @order_address.phone_num = phone
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Phone num は（半角数字）10~11文字で入力する必要があります")
+        end
+      end
+      it "userが紐づいていない状態では購入できない" do
+        @order_address.user = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("User can't be blank")
+      end
+      it "itemが紐づいていない状態では購入できない" do
+        @order_address.item = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Item can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe OrderAddress, type: :model do
         @order_address.valid?
         expect(@order_address.errors.full_messages).to include("Item can't be blank")
       end
+      it "tokenが空では購入できない" do
+        @order_address.token = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      end 
     end
   end
 end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe OrderAddress, type: :model do
         end
       end
       it "userが紐づいていない状態では購入できない" do
-        @order_address.user = nil
+        @order_address.user_id = nil
         @order_address.valid?
         expect(@order_address.errors.full_messages).to include("User can't be blank")
       end
       it "itemが紐づいていない状態では購入できない" do
-        @order_address.item = nil
+        @order_address.item_id = nil
         @order_address.valid?
         expect(@order_address.errors.full_messages).to include("Item can't be blank")
       end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
# What
- PAY.JPを導入しクレジットカードを用いた購入機能の実装
- 購入済みの可否で表示の変更、購入済みの商品は購入画面へ遷移できないように実装

# Why
- web上で購入までできることで利便性が向上する。支払い代行を用いることで安全に金銭のやり取りを行うことができるため。
- 商品購入情報の重複を避けるため。

## gyazo
-  必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/d934aed3be183871a26ef193ffc8da34

-  入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/356d2a0680b9476bea720fc76297bd49

-  ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/70f0a67c5ea002093b54f74344be4e33

-  ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/480760143b3c97d9d46811751b91d68c

-  ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/0b1c1ca01ffca41762cae8044c47d73e

-  売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/bb225bf88b860901b759673c993970af

-  売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
-  ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/a0921764efa93eb40d79a70a08fbfbef
https://gyazo.com/7d474895a1f0386d8ba0ce0dbc3c82b0

-  ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/3203df3c39a590d843c592b7fa60232a

-  テスト結果の画像
https://gyazo.com/56a9b00a1029e45e57dc2a2caf2fcf6a